### PR TITLE
feat: add Stage 3 dataset loader

### DIFF
--- a/local_code/stage_3_code/Dataset_Loader.py
+++ b/local_code/stage_3_code/Dataset_Loader.py
@@ -5,18 +5,18 @@ Concrete IO class for a specific dataset
 # Copyright (c) 2017-Current Jiawei Zhang <jiawei@ifmlab.org>
 # License: TBD
 
+import pickle
 from local_code.base_class.dataset import dataset
-
+from typing import Literal
 
 class Dataset_Loader(dataset):
     data = None
     dataset_source_folder_path = None
     dataset_source_file_name = None
     
-    def __init__(self, dName=None, dDescription=None, training_data_file="", test_data_file=""):
+    def __init__(self, dName=None, dDescription=None, data_file: Literal["ORL", "CIFAR", "MNIST"] = "ORL"):
         super().__init__(dName, dDescription)
-        self.training_data_file = training_data_file
-        self.test_data_file = test_data_file
+        self.data_file = data_file
     
     def load(self):
         print('loading data...')
@@ -30,16 +30,16 @@ class Dataset_Loader(dataset):
                 "y": []
             }
         }
-        with open(self.dataset_source_folder_path + self.training_data_file, 'r') as f:
-            for line in f:
-                line = line.strip('\n')
-                elements = [int(i) for i in line.split(',')]
-                result["training_data"]["X"].append(elements[1:])
-                result["training_data"]["y"].append(elements[0])
-        with open(self.dataset_source_folder_path + self.test_data_file, 'r') as f:
-            for line in f:
-                line = line.strip('\n')
-                elements = [int(i) for i in line.split(',')]
-                result["test_data"]["X"].append(elements[1:])
-                result["test_data"]["y"].append(elements[0])
+        with open(self.dataset_source_folder_path + self.data_file, 'rb') as f:
+            data = pickle.load(f)
+            for instance in data['train']:
+                image_matrix = instance['image']
+                image_label = instance['label']
+                result["training_data"]["X"].append(image_matrix)
+                result["training_data"]["y"].append(image_label)
+            for instance in data['test']:
+                image_matrix = instance['image']
+                image_label = instance['label']
+                result["test_data"]["X"].append(image_matrix)
+                result["test_data"]["y"].append(image_label)
         return result

--- a/script/stage_3_script/tests.py
+++ b/script/stage_3_script/tests.py
@@ -1,0 +1,10 @@
+from local_code.stage_3_code.Dataset_Loader import Dataset_Loader
+
+# test data loader
+data_path = './data/stage_3_data/'
+
+dataset = Dataset_Loader('stage 3 data train', '', data_file='ORL')
+dataset.dataset_source_folder_path = data_path
+
+result = dataset.load()
+print(result)


### PR DESCRIPTION
## 🆕 Add Stage 3 Dataset Loader and Test Script for Image Classification

### Summary
- Added a new dataset loader using `pickle` for image classification datasets (e.g., ORL, CIFAR).
- Replaced old text file loading logic with binary `.pkl` support.
- Added `tests.py` script to load and print dataset and can be used for future tests.

### Changes
- Updated `Dataset_loader.py` in `stage_3_code`
- Created `script/stage_3_script/tests.py`

### Notes
Tested with sample ORL data — loads and prints image/label pairs as expected.